### PR TITLE
check if the element of unread-conversations is available

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,7 +1,12 @@
 module.exports = (Franz) => {
   function getUnreadConversations() {
     let unreadConversations = 0;
-    unreadConversations = parseInt(document.querySelector('#unread-conversations').innerHTML, 10);
+    let unreadConvElement = document.querySelector('#unread-conversations');
+    
+    // on logged-out, we do not have such an element, check first!
+    if (unreadConvElement !== null && unreadConvElement.innerHTM) {
+      unreadConversations = parseInt(unreadConvElement.innerHTML, 10);
+    }
 
     Franz.setBadge(unreadConversations);
   }


### PR DESCRIPTION
In the logged-out view, there is no such element and hence, this produces noise as the exception is not catched.